### PR TITLE
[#2] Add contrib dir for Arcadis

### DIFF
--- a/contrib/Arcadis/README.md
+++ b/contrib/Arcadis/README.md
@@ -1,0 +1,11 @@
+## Purpose
+This subdir is aimed at contributions from Arcadis on various topics,
+amongst others stochastic D-HYDRO runs.
+Consider this as a sandbox environment where related scripts can also
+be placed, which can later be cleaned up and promoted into HYDROLIB-core
+for example.
+
+## Contact
+[@abuijert]( https://github.com/abuijert )
+[@stefandevriesarcadis]( https://github.com/stefandevriesarcadis )
+[@myrthearcadis]( https://github.com/myrthearcadis )


### PR DESCRIPTION
Set up initial contrib directory to let Arcadis people start in their own sandbox environment, focused mainly (but not solely) on the stochastic D-HYDRO runs.
Fix #2.