### PR TITLE
33/generate 1 d 2 d links from 2 d to 1 d

### DIFF
--- a/hydrolib/dhydamo/geometry/mesh.py
+++ b/hydrolib/dhydamo/geometry/mesh.py
@@ -272,3 +272,211 @@ def _filter_links_on_idx(network: Network, keep: np.ndarray) -> None:
     ]
     network._link1d2d.link1d2d_id = network._link1d2d.link1d2d_id[keep]
     network._link1d2d.link1d2d_long_name = network._link1d2d.link1d2d_long_name[keep]
+
+
+def links1d2d_add_links_2d_to_1d_embedded(
+    network: Network,
+    branchids: List[str] = None,
+    within: Union[Polygon, MultiPolygon] = None,
+) -> None:
+    """Generates links from 2d to 1d, where the 2d mesh intersects the 1d mesh: the 'embedded' links.
+
+    To find the intersecting cells in an efficient way, we follow we the next steps. 1) Get the
+    maximum length of a face edge. 2) Buffer the branches with this length. 3) Find all face nodes
+    within this buffered geometry. 4) Check for each of the corresponding faces if it crossed the
+    branches.
+
+    Args:
+        network (Network): Network in which the links are made. Should contain a 1d and 2d mesh
+        branchids (List[str], optional): List is branch id's for which the connections are made. Defaults to None.
+        within (Union[Polygon, MultiPolygon], optional): Clipping polygon for 2d mesh that is. Defaults to None.
+
+    """
+    # Load 1d and 2d in meshkernel
+    network._mesh1d._set_mesh1d()
+    network._mesh2d._set_mesh2d()
+
+    # Get the max edge distance
+    nodes2d = np.stack(
+        [network._mesh2d.mesh2d_node_x, network._mesh2d.mesh2d_node_y], axis=1
+    )
+    edge_node_crds = nodes2d[network._mesh2d.mesh2d_edge_nodes]
+
+    diff = edge_node_crds[:, 0, :] - edge_node_crds[:, 1, :]
+    maxdiff = np.hypot(diff[:, 0], diff[:, 1]).max()
+
+    # Create multilinestring from branches
+    # branchnrs = np.unique(network._mesh1d.mesh1d_node_branch_id)
+    nodes1d = np.stack(
+        [network._mesh1d.mesh1d_node_x, network._mesh1d.mesh1d_node_y], axis=1
+    )
+
+    # Create a prepared multilinestring of the 1d network, to check for intersections
+    mls = MultiLineString(nodes1d[network._mesh1d.mesh1d_edge_nodes].tolist())
+    mls_prep = prep(mls)
+
+    # Buffer the branches with the max cell distances
+    area = mls.buffer(maxdiff)
+
+    # If a within polygon is provided, clip the buffered area with this polygon.
+    if within is not None:
+        area = area.intersection(within)
+
+    # Create an array with 2d facecenters and check which intersect the (clipped) area
+    faces2d = np.stack(
+        [network._mesh2d.mesh2d_face_x, network._mesh2d.mesh2d_face_y], axis=1
+    )
+    mpgl = GeometryList(*faces2d.T.copy())
+    idx = np.zeros(len(faces2d), dtype=bool)
+    for subarea in common.as_polygon_list(area):
+        subarea = GeometryList.from_geometry(subarea)
+        idx |= (
+            network.meshkernel.polygon_get_included_points(subarea, mpgl).values == 1.0
+        )
+
+    # Check for each of the remaining faces, if it actually crosses the branches
+    nodes2d = np.stack(
+        [network._mesh2d.mesh2d_node_x, network._mesh2d.mesh2d_node_y], axis=1
+    )
+    where = np.where(idx)[0]
+    for i, face_crds in enumerate(nodes2d[network._mesh2d.mesh2d_face_nodes[idx]]):
+        if not mls_prep.intersects(LineString(face_crds)):
+            idx[where[i]] = False
+
+    # Use the remaining points to create the links
+    multipoint = GeometryList(
+        x_coordinates=faces2d[idx, 0], y_coordinates=faces2d[idx, 1]
+    )
+
+    # Get the nodes for the specific branch ids
+    # TODO: The node mask does not seem to work
+    node_mask = network._mesh1d.get_node_mask(branchids)
+
+    # Generate links
+    network._link1d2d._link_from_2d_to_1d_embedded(node_mask, points=multipoint)
+
+
+def links1d2d_add_links_2d_to_1d_lateral(
+    network: Network,
+    dist_factor: Union[float, None] = 2.0,
+    branchids: List[str] = None,
+    within: Union[Polygon, MultiPolygon] = None,
+    max_length: float = np.inf,
+) -> None:
+    """Generate 1d2d links from the 2d mesh to the 1d mesh, with a lateral connection.
+    If a link is kept, is determined based on the distance between the face center and
+    the intersection with the 2d mesh exterior. By default, links with an intersection
+    distance larger than 2 times the center to edge distance of the cell, are removed.
+    Note that for a square cell with a direct link out of the cell (without passing any
+    other cells) this max distance is sqrt(2) = 1.414. The default value of 2 provides
+    some flexibility. Note that a link with more than 1 intersection with the 2d mesh
+    boundary is removed anyway.
+
+    Furthermore:
+    - Branch ids can be specified to connect only specific branches.
+    - A 'within' polygon can be given to only connect 2d cells within this polygon.
+    - A max link length can be given to limit the link length.
+
+    Args:
+        network (Network): Network in which the links are made. Should contain a 1d and 2d mesh
+        dist_factor (Union[float, None], optional): Factor to determine which links are kept (see description above). Defaults to 2.0.
+        branchids (List[str], optional): List is branch id's for which the conncetions are made. Defaults to None.
+        within (Union[Polygon, MultiPolygon], optional): Clipping polygon for 2d mesh that is. Defaults to None.
+        max_length (float, optional): Max edge length. Defaults to None.
+    """
+
+    # Load 1d and 2d in meshkernel
+    network._mesh1d._set_mesh1d()
+    network._mesh2d._set_mesh2d()
+
+    geometrylist = network.meshkernel.mesh2d_get_mesh_boundaries_as_polygons()
+    mpboundaries = GeometryList(**geometrylist.__dict__).to_geometry()
+    if within is not None:
+        # If a 'within' polygon was provided, get the intersection with the meshboundaries
+        # and convert it to a geometrylist
+        # Note that the provided meshboundaries is a (list of) polygon(s). Holes are provided
+        # as polygons as well, which dont make it a valid MultiPolygon
+        geometrylist = GeometryList.from_geometry(
+            MultiPolygon(
+                common.as_polygon_list(
+                    [geom.intersection(within) for geom in mpboundaries.geoms]
+                )
+            )
+        )
+
+    # Get the nodes for the specific branch ids
+    node_mask = network._mesh1d.get_node_mask(branchids)
+
+    # Get the already present links. These are not filtered subsequently
+    npresent = len(network._link1d2d.link1d2d)
+
+    # Generate links
+    network._link1d2d._link_from_2d_to_1d_lateral(
+        node_mask, polygon=geometrylist, search_radius=max_length
+    )
+
+    # If the provided distance factor was None, no further selection is needed, all links are kept.
+    if dist_factor is None:
+        return
+
+    # Create multilinestring
+    multilinestring = MultiLineString([poly.exterior for poly in mpboundaries.geoms])
+
+    # Find the links that intersect the boundary close to the origin
+    id1d = network._link1d2d.link1d2d[npresent:, 0]
+    id2d = network._link1d2d.link1d2d[npresent:, 1]
+
+    nodes1d = np.stack(
+        [network._mesh1d.mesh1d_node_x[id1d], network._mesh1d.mesh1d_node_y[id1d]],
+        axis=1,
+    )
+    faces2d = np.stack(
+        [network._mesh2d.mesh2d_face_x[id2d], network._mesh2d.mesh2d_face_y[id2d]],
+        axis=1,
+    )
+    nodes2d = np.stack(
+        [network._mesh2d.mesh2d_node_x, network._mesh2d.mesh2d_node_y], axis=1
+    )
+    face_node_crds = nodes2d[network._mesh2d.mesh2d_face_nodes[id2d]]
+
+    # Calculate distance between face edge and face center
+    x1 = np.take(face_node_crds, 0, axis=2)
+    y1 = np.take(face_node_crds, 1, axis=2)
+    face_node_crds[:] = np.roll(face_node_crds, 1, axis=1)
+    x2 = np.take(face_node_crds, 0, axis=2)
+    y2 = np.take(face_node_crds, 1, axis=2)
+    x0, y0 = faces2d[:, 0], faces2d[:, 1]
+    distance = (
+        np.absolute((x2 - x1) * (y1 - y0[:, None]) - (x1 - x0[:, None]) * (y2 - y1))
+        / np.hypot(x2 - x1, y2 - y1)
+    ).mean(axis=1)
+
+    # Check which links to keep
+    keep = list(range(npresent))
+    for i, (node1d, face2d, comp_dist) in enumerate(
+        zip(nodes1d, faces2d, distance * dist_factor)
+    ):
+        isect = multilinestring.intersection(LineString([face2d, node1d]))
+
+        # If the intersection is for some reason not a Point of Multipoint, skip it.
+        if not isinstance(isect, (Point, MultiPoint)):
+            continue
+
+        # Skip the link if it has more than one intersection with the boundary
+        isect_list = common.as_point_list(isect)
+        if len(isect_list) != 1:
+            continue
+
+        # If the distance to the mesh 2d exterior intersection is smaller than
+        # the compared distance, keep it.
+        dist = np.hypot(*(face2d - isect_list[0]))
+        if dist < comp_dist:
+            keep.append(i)
+
+    # Select the remaining links
+    network._link1d2d.link1d2d = network._link1d2d.link1d2d[keep]
+    network._link1d2d.link1d2d_contact_type = network._link1d2d.link1d2d_contact_type[
+        keep
+    ]
+    network._link1d2d.link1d2d_id = network._link1d2d.link1d2d_id[keep]
+    network._link1d2d.link1d2d_long_name = network._link1d2d.link1d2d_long_name[keep]

--- a/hydrolib/dhydamo/geometry/mesh.py
+++ b/hydrolib/dhydamo/geometry/mesh.py
@@ -1,14 +1,19 @@
 from typing import List, Union
 
 import numpy as np
-from shapely.geometry import LineString, MultiLineString, MultiPolygon, Polygon
+from shapely.geometry import (
+    LineString,
+    MultiLineString,
+    MultiPolygon,
+    Polygon,
+    Point,
+    MultiPoint,
+)
+from shapely.prepared import prep
 
 from hydrolib.core.io.net.models import Branch, Network
 from hydrolib.dhydamo.geometry import common
 from hydrolib.dhydamo.geometry.models import GeometryList
-
-
-
 
 
 def mesh2d_add_rectilinear(
@@ -181,3 +186,211 @@ def mesh1d_add_branch(
         branch = Branch(geometry=np.array(line.coords[:]))
         branch.generate_nodes(node_distance)
         network.mesh1d_add_branch(branch)
+
+
+def links1d2d_add_links_2d_to_1d_embedded(
+    network: Network,
+    branchids: List[str] = None,
+    within: Union[Polygon, MultiPolygon] = None,
+) -> None:
+    """Generates links from 2d to 1d, where the 2d mesh intersects the 1d mesh: the 'embedded' links.
+
+    To find the intersecting cells in an efficient way, we follow we the next steps. 1) Get the
+    maximum length of a face edge. 2) Buffer the branches with this length. 3) Find all face nodes
+    within this buffered geometry. 4) Check for each of the corresponding faces if it crossed the
+    branches.
+
+    Args:
+        network (Network): Network in which the links are made. Should contain a 1d and 2d mesh
+        branchids (List[str], optional): List is branch id's for which the connections are made. Defaults to None.
+        within (Union[Polygon, MultiPolygon], optional): Clipping polygon for 2d mesh that is. Defaults to None.
+
+    """
+    # Load 1d and 2d in meshkernel
+    network._mesh1d._set_mesh1d()
+    network._mesh2d._set_mesh2d()
+
+    # Get the max edge distance
+    nodes2d = np.stack(
+        [network._mesh2d.mesh2d_node_x, network._mesh2d.mesh2d_node_y], axis=1
+    )
+    edge_node_crds = nodes2d[network._mesh2d.mesh2d_edge_nodes]
+
+    diff = edge_node_crds[:, 0, :] - edge_node_crds[:, 1, :]
+    maxdiff = np.hypot(diff[:, 0], diff[:, 1]).max()
+
+    # Create multilinestring from branches
+    # branchnrs = np.unique(network._mesh1d.mesh1d_node_branch_id)
+    nodes1d = np.stack(
+        [network._mesh1d.mesh1d_node_x, network._mesh1d.mesh1d_node_y], axis=1
+    )
+
+    # Create a prepared multilinestring of the 1d network, to check for intersections
+    mls = MultiLineString(nodes1d[network._mesh1d.mesh1d_edge_nodes].tolist())
+    mls_prep = prep(mls)
+
+    # Buffer the branches with the max cell distances
+    area = mls.buffer(maxdiff)
+
+    # If a within polygon is provided, clip the buffered area with this polygon.
+    if within is not None:
+        area = area.intersection(within)
+
+    # Create an array with 2d facecenters and check which intersect the (clipped) area
+    faces2d = np.stack(
+        [network._mesh2d.mesh2d_face_x, network._mesh2d.mesh2d_face_y], axis=1
+    )
+    mpgl = GeometryList(*faces2d.T.copy())
+    idx = np.zeros(len(faces2d), dtype=bool)
+    for subarea in common.as_polygon_list(area):
+        subarea = GeometryList.from_geometry(subarea)
+        idx |= (
+            network.meshkernel.polygon_get_included_points(subarea, mpgl).values == 1.0
+        )
+
+    # Check for each of the remaining faces, if it actually crosses the branches
+    nodes2d = np.stack(
+        [network._mesh2d.mesh2d_node_x, network._mesh2d.mesh2d_node_y], axis=1
+    )
+    where = np.where(idx)[0]
+    for i, face_crds in enumerate(nodes2d[network._mesh2d.mesh2d_face_nodes[idx]]):
+        if not mls_prep.intersects(LineString(face_crds)):
+            idx[where[i]] = False
+
+    # Use the remaining points to create the links
+    multipoint = GeometryList(
+        x_coordinates=faces2d[idx, 0], y_coordinates=faces2d[idx, 1]
+    )
+
+    # Get the nodes for the specific branch ids
+    # TODO: The node mask does not seem to work
+    node_mask = network._mesh1d.get_node_mask(branchids)
+
+    # Generate links
+    network._link1d2d._link_from_2d_to_1d_intersecting(node_mask, points=multipoint)
+
+
+def links1d2d_add_links_2d_to_1d_lateral(
+    network: Network,
+    dist_factor: Union[float, None] = 2.0,
+    branchids: List[str] = None,
+    within: Union[Polygon, MultiPolygon] = None,
+    max_length: float = np.inf,
+) -> None:
+    """Generate 1d2d links from the 2d mesh to the 1d mesh, with a lateral connection.
+    If a link is kept, is determined based on the distance between the face center and
+    the intersection with the 2d mesh exterior. By default, links with an intersection
+    distance larger than 2 times the center to edge distance of the cell, are removed.
+    Note that for a square cell with a direct link out of the cell (without passing any
+    other cells) this max distance is sqrt(2) = 1.414. The default value of 2 provides
+    some flexibility. Note that a link with more than 1 intersection with the 2d mesh
+    boundary is removed anyway.
+
+    Furthermore:
+    - Branch ids can be specified to connect only specific branches.
+    - A 'within' polygon can be given to only connect 2d cells within this polygon.
+    - A max link length can be given to limit the link length.
+
+    Args:
+        network (Network): Network in which the links are made. Should contain a 1d and 2d mesh
+        dist_factor (Union[float, None], optional): Factor to determine which links are kept (see description above). Defaults to 2.0.
+        branchids (List[str], optional): List is branch id's for which the conncetions are made. Defaults to None.
+        within (Union[Polygon, MultiPolygon], optional): Clipping polygon for 2d mesh that is. Defaults to None.
+        max_length (float, optional): Max edge length. Defaults to None.
+    """
+
+    # Load 1d and 2d in meshkernel
+    network._mesh1d._set_mesh1d()
+    network._mesh2d._set_mesh2d()
+
+    geometrylist = network.meshkernel.mesh2d_get_mesh_boundaries_as_polygons()
+    mpboundaries = GeometryList(**geometrylist.__dict__).to_geometry()
+    if within is not None:
+        # If a 'within' polygon was provided, get the intersection with the meshboundaries
+        # and convert it to a geometrylist
+        # Note that the provided meshboundaries is a (list of) polygon(s). Holes are provided
+        # as polygons as well, which dont make it a valid MultiPolygon
+        geometrylist = GeometryList.from_geometry(
+            MultiPolygon(
+                common.as_polygon_list(
+                    [geom.intersection(within) for geom in mpboundaries.geoms]
+                )
+            )
+        )
+
+    # Get the nodes for the specific branch ids
+    node_mask = network._mesh1d.get_node_mask(branchids)
+
+    # Get the already present links. These are not filtered subsequently
+    npresent = len(network._link1d2d.link1d2d)
+
+    # Generate links
+    network._link1d2d._link_from_2d_to_1d_lateral(
+        node_mask, polygon=geometrylist, search_radius=max_length
+    )
+
+    # If the provided distance factor was None, no further selection is needed, all links are kept.
+    if dist_factor is None:
+        return
+
+    # Create multilinestring
+    multilinestring = MultiLineString([poly.exterior for poly in mpboundaries.geoms])
+
+    # Find the links that intersect the boundary close to the origin
+    id1d = network._link1d2d.link1d2d[npresent:, 0]
+    id2d = network._link1d2d.link1d2d[npresent:, 1]
+
+    nodes1d = np.stack(
+        [network._mesh1d.mesh1d_node_x[id1d], network._mesh1d.mesh1d_node_y[id1d]],
+        axis=1,
+    )
+    faces2d = np.stack(
+        [network._mesh2d.mesh2d_face_x[id2d], network._mesh2d.mesh2d_face_y[id2d]],
+        axis=1,
+    )
+    nodes2d = np.stack(
+        [network._mesh2d.mesh2d_node_x, network._mesh2d.mesh2d_node_y], axis=1
+    )
+    face_node_crds = nodes2d[network._mesh2d.mesh2d_face_nodes[id2d]]
+
+    # Calculate distance between face edge and face center
+    x1 = np.take(face_node_crds, 0, axis=2)
+    y1 = np.take(face_node_crds, 1, axis=2)
+    face_node_crds[:] = np.roll(face_node_crds, 1, axis=1)
+    x2 = np.take(face_node_crds, 0, axis=2)
+    y2 = np.take(face_node_crds, 1, axis=2)
+    x0, y0 = faces2d[:, 0], faces2d[:, 1]
+    distance = (
+        np.absolute((x2 - x1) * (y1 - y0[:, None]) - (x1 - x0[:, None]) * (y2 - y1))
+        / np.hypot(x2 - x1, y2 - y1)
+    ).mean(axis=1)
+
+    # Check which links to keep
+    keep = list(range(npresent))
+    for i, (node1d, face2d, comp_dist) in enumerate(
+        zip(nodes1d, faces2d, distance * dist_factor)
+    ):
+        isect = multilinestring.intersection(LineString([face2d, node1d]))
+
+        # If the intersection is for some reason not a Point of Multipoint, skip it.
+        if not isinstance(isect, (Point, MultiPoint)):
+            continue
+
+        # Skip the link if it has more than one intersection with the boundary
+        isect_list = common.as_point_list(isect)
+        if len(isect_list) != 1:
+            continue
+
+        # If the distance to the mesh 2d exterior intersection is smaller than
+        # the compared distance, keep it.
+        dist = np.hypot(*(face2d - isect_list[0]))
+        if dist < comp_dist:
+            keep.append(i)
+
+    # Select the remaining links
+    network._link1d2d.link1d2d = network._link1d2d.link1d2d[keep]
+    network._link1d2d.link1d2d_contact_type = network._link1d2d.link1d2d_contact_type[
+        keep
+    ]
+    network._link1d2d.link1d2d_id = network._link1d2d.link1d2d_id[keep]
+    network._link1d2d.link1d2d_long_name = network._link1d2d.link1d2d_long_name[keep]

--- a/tests/dhydamo/geometry/test_mesh.py
+++ b/tests/dhydamo/geometry/test_mesh.py
@@ -417,3 +417,108 @@ def test_1d_add_branch():
     for ls in common.as_linestring_list(branches):
         ax.plot(*ls.coords.xy, color="k", ls="-", lw=3, alpha=0.2)
     plt.show()
+
+
+def _prepare_1d2d_mesh():
+    # Define polygon
+    fmmodel = FMModel()
+    network = fmmodel.geometry.netfile.network
+
+    # Generate 1d
+    branch = [LineString([[-9, -3], [0, 4]]), LineString([[0, 4], [10, -10]])]
+    branchids = mesh.mesh1d_add_branch(network, branches=branch, node_distance=1)
+
+    # Generate 2d
+    areas = MultiPolygon([box(-8, -10, 8, -2), box(-8, 2, 8, 10)])
+    hole = box(-6, -6, 6, -4)
+    mesh.mesh2d_add_rectilinear(network, areas, dx=0.5, dy=0.5)
+    mesh.mesh2d_clip(network, hole)
+
+    within = box(-10, -10, 12, 10).difference(
+        LineString([[-2, -10], [2, 10]]).buffer(2)
+    )
+
+    return network, within, branchids
+
+
+@pytest.mark.plots
+def test_links1d2d_add_links_2d_to_1d_embedded():
+
+    network, within, branchids = _prepare_1d2d_mesh()
+
+    # Generate all links
+    mesh.links1d2d_add_links_2d_to_1d_embedded(network)
+    assert len(network._link1d2d.link1d2d) == 35
+    network._link1d2d.clear()
+
+    # TODO: The node mask does not seem to work. Fix in meshkernel
+    # Generate links within polygon, with smaller distance factor, with max length, and for the first branch
+    # mesh.links1d2d_add_links_2d_to_1d_embedded(
+    #     network, within=within, branchids=[branchids[0]]
+    # )
+    # assert len(network._link1d2d.link1d2d) == 22
+    # network._link1d2d.clear()
+
+    # Generate links within polygon
+    mesh.links1d2d_add_links_2d_to_1d_embedded(network, within=within)
+    assert len(network._link1d2d.link1d2d) == 22
+
+    # Plot to verify
+    fig, ax = plt.subplots(figsize=(5, 5))
+
+    viz.plot_network(network, ax=ax)
+
+    for polygon in common.as_polygon_list(within):
+        ax.fill(*polygon.exterior.coords.xy, color="g", ls="-", lw=0, alpha=0.05)
+        ax.plot(*polygon.exterior.coords.xy, color="g", ls="-", lw=0.5)
+    ax.set_aspect(1.0)
+    ax.autoscale_view()
+
+    plt.show()
+
+
+@pytest.mark.plots
+def test_links1d2d_add_links_2d_to_1d_lateral():
+
+    network, within, branchids = _prepare_1d2d_mesh()
+
+    # Generate all links
+    mesh.links1d2d_add_links_2d_to_1d_lateral(network)
+    assert len(network._link1d2d.link1d2d) == 55
+    network._link1d2d.clear()
+
+    # Generate links within polygon and with smaller distance factor
+    mesh.links1d2d_add_links_2d_to_1d_lateral(network, within=within, dist_factor=1.5)
+    assert len(network._link1d2d.link1d2d) == 31
+    network._link1d2d.clear()
+
+    # Generate links within polygon, with smaller distance factor, and with max length
+    mesh.links1d2d_add_links_2d_to_1d_lateral(
+        network, within=within, dist_factor=1.5, max_length=2
+    )
+    assert len(network._link1d2d.link1d2d) == 20
+    network._link1d2d.clear()
+
+    # Generate links within polygon, with smaller distance factor, with max length, and for the first branch
+    mesh.links1d2d_add_links_2d_to_1d_lateral(
+        network, within=within, dist_factor=1.5, max_length=2, branchids=[branchids[0]]
+    )
+    assert len(network._link1d2d.link1d2d) == 11
+    network._link1d2d.clear()
+
+    # Generate links within polygon
+    mesh.links1d2d_add_links_2d_to_1d_lateral(network, within=within)
+    assert len(network._link1d2d.link1d2d) == 47
+
+    # Plot the final result verify
+    fig, ax = plt.subplots(figsize=(5, 5))
+
+    viz.plot_network(network, ax=ax)
+
+    for polygon in common.as_polygon_list(within):
+        ax.fill(*polygon.exterior.coords.xy, color="g", ls="-", lw=0, alpha=0.05)
+        ax.plot(*polygon.exterior.coords.xy, color="g", ls="-", lw=0.5)
+    ax.set_aspect(1.0)
+    ax.autoscale_view()
+
+    plt.show()

--- a/tests/dhydamo/geometry/test_mesh.py
+++ b/tests/dhydamo/geometry/test_mesh.py
@@ -481,3 +481,86 @@ def test_links1d2d_add_links_1d_to_2d():
     ax.autoscale_view()
 
     plt.show()
+
+
+@pytest.mark.plots
+def test_links1d2d_add_links_2d_to_1d_embedded():
+
+    network, within, branchids = _prepare_1d2d_mesh()
+
+    # Generate all links
+    mesh.links1d2d_add_links_2d_to_1d_embedded(network)
+    assert len(network._link1d2d.link1d2d) == 35
+    network._link1d2d.clear()
+
+    # TODO: The node mask does not seem to work. Fix in meshkernel
+    # Generate links within polygon, with smaller distance factor, with max length, and for the first branch
+    # mesh.links1d2d_add_links_2d_to_1d_embedded(
+    #     network, within=within, branchids=[branchids[0]]
+    # )
+    # assert len(network._link1d2d.link1d2d) == 22
+    # network._link1d2d.clear()
+
+    # Generate links within polygon
+    mesh.links1d2d_add_links_2d_to_1d_embedded(network, within=within)
+    assert len(network._link1d2d.link1d2d) == 22
+
+    # Plot to verify
+    fig, ax = plt.subplots(figsize=(5, 5))
+
+    viz.plot_network(network, ax=ax)
+
+    for polygon in common.as_polygon_list(within):
+        ax.fill(*polygon.exterior.coords.xy, color="g", ls="-", lw=0, alpha=0.05)
+        ax.plot(*polygon.exterior.coords.xy, color="g", ls="-", lw=0.5)
+    ax.set_aspect(1.0)
+    ax.autoscale_view()
+
+    plt.show()
+
+
+@pytest.mark.plots
+def test_links1d2d_add_links_2d_to_1d_lateral():
+
+    network, within, branchids = _prepare_1d2d_mesh()
+
+    # Generate all links
+    mesh.links1d2d_add_links_2d_to_1d_lateral(network)
+    assert len(network._link1d2d.link1d2d) == 55
+    network._link1d2d.clear()
+
+    # Generate links within polygon and with smaller distance factor
+    mesh.links1d2d_add_links_2d_to_1d_lateral(network, within=within, dist_factor=1.5)
+    assert len(network._link1d2d.link1d2d) == 31
+    network._link1d2d.clear()
+
+    # Generate links within polygon, with smaller distance factor, and with max length
+    mesh.links1d2d_add_links_2d_to_1d_lateral(
+        network, within=within, dist_factor=1.5, max_length=2
+    )
+    assert len(network._link1d2d.link1d2d) == 20
+    network._link1d2d.clear()
+
+    # Generate links within polygon, with smaller distance factor, with max length, and for the first branch
+    mesh.links1d2d_add_links_2d_to_1d_lateral(
+        network, within=within, dist_factor=1.5, max_length=2, branchids=[branchids[0]]
+    )
+    assert len(network._link1d2d.link1d2d) == 11
+    network._link1d2d.clear()
+
+    # Generate links within polygon
+    mesh.links1d2d_add_links_2d_to_1d_lateral(network, within=within)
+    assert len(network._link1d2d.link1d2d) == 47
+
+    # Plot the final result verify
+    fig, ax = plt.subplots(figsize=(5, 5))
+
+    viz.plot_network(network, ax=ax)
+
+    for polygon in common.as_polygon_list(within):
+        ax.fill(*polygon.exterior.coords.xy, color="g", ls="-", lw=0, alpha=0.05)
+        ax.plot(*polygon.exterior.coords.xy, color="g", ls="-", lw=0.5)
+    ax.set_aspect(1.0)
+    ax.autoscale_view()
+
+    plt.show()


### PR DESCRIPTION
Added functions for adding 1d2d links from 2d to 1d. Two possibilities:
- Generate links from intersecting 2D cells to 1D (embedded)
- Generate links from near 2D cells to 1D, without intersecting other cells (lateral)

Possibilities:
- Generate 1d-2d links, from 2D to 1D.
- Specify branch to which connections are generated (or maybe the 2D area in which links are generated)
- Specify a polygon within which links are created, in case the above option is not sufficiently accurate.
- Specify max link (or node to face-edge distance) in case of lateral links

