### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ jupyter = "^1.0.0"
 contextily = "^1.0.1"
 dask = "2023.5.0"
 pyogrio = "^0.9.0"
+shapely = "^2.0.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"


### PR DESCRIPTION
Shapely moet versie 2.0.2 of hoger zijn ivm shapely functie shapely.from_wbt wordt gebruikt in class extendedgeodataframe.read_gpkg_layer. Anders functioneert de gehele klasse niet