### PR TITLE
fix: update permissions for deployment job in docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,11 +6,14 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: 3.12
+
       - run: pipx install poetry
       - run: poetry install --only dev --no-root --no-interaction
       - run: poetry run mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: write` to the `deploy` job in `.github/workflows/docs.yml` so
  `mkdocs gh-deploy --force` can push the built site to the `gh-pages` branch with the default
  `GITHUB_TOKEN`.
- Without this, the build succeeds but the push step fails with HTTP 403
  (`Permission to Deltares/HYDROLIB.git denied to github-actions[bot]`).

Tracked in #220. Closes #218.

## Test plan

- [ ] Merge to `main` and confirm the `docs` workflow run completes both build and push steps
- [ ] Verify https://deltares.github.io/HYDROLIB/ updates with the latest build
- [ ] If the push still 403s after merge, escalate to a repo admin to flip
      Settings → Actions → General → Workflow permissions to "Read and write" (out of scope here)